### PR TITLE
Replace deprecated 'setting_getbool' with 'settings:get_bool'

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -172,7 +172,7 @@ function spidermob:register_mob(name, def)
 		
 		on_step = function(self, dtime)
 			
-			if self.type == "monster" and minetest.setting_getbool("only_peaceful_spidermob") then
+			if self.type == "monster" and minetest.settings:get_bool("only_peaceful_spidermob") then
 				self.object:remove()
 			end
 			
@@ -295,7 +295,7 @@ function spidermob:register_mob(name, def)
 			end
 			
 			-- FIND SOMEONE TO ATTACK
-			if ( self.type == "monster" or self.type == "barbarian" ) and minetest.setting_getbool("enable_damage") and self.state ~= "attack" then
+			if ( self.type == "monster" or self.type == "barbarian" ) and minetest.settings:get_bool("enable_damage") and self.state ~= "attack" then
 				local s = self.object:getpos()
 				local inradius = minetest.get_objects_inside_radius(s,self.view_range)
 				local player = nil
@@ -594,7 +594,7 @@ function spidermob:register_mob(name, def)
 			self.state = "stand"
 			self.object:setvelocity({x=0, y=self.object:getvelocity().y, z=0})
 			self.object:setyaw(math.random(1, 360)/180*math.pi)
-			if self.type == "monster" and minetest.setting_getbool("only_peaceful_spidermob") then
+			if self.type == "monster" and minetest.settings:get_bool("only_peaceful_spidermob") then
 				self.object:remove()
 			end
 			if self.type ~= "npc" then
@@ -822,7 +822,7 @@ function spidermob:register_spawn(name, nodes, max_light, min_light, chance, act
 				return
 			end
 
-			if minetest.setting_getbool("display_mob_spawn") then
+			if minetest.settings:get_bool("display_mob_spawn") then
 				minetest.chat_send_all("[spidermob] Add "..name.." at "..minetest.pos_to_string(pos))
 			end
 			local mob = minetest.add_entity(pos, name)


### PR DESCRIPTION
May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267